### PR TITLE
Ignore exceptions when sending photos

### DIFF
--- a/src/worker/send_notification.cr
+++ b/src/worker/send_notification.cr
@@ -38,12 +38,7 @@ module Worker
       )
       unless toy.images.empty?
         toy.images.each do |image|
-          bot.send_photo(
-            chat_id: watcher,
-            photo: image.full_filename,
-            disable_notification: true,
-            reply_to_message_id: msg == nil ? nil : msg.not_nil!.message_id
-          )
+          send_photo(watcher, toy, bot, image, msg)
         end
       end
     end
@@ -60,6 +55,17 @@ module Worker
 
     private def build_clearance_url(toy)
       "https://bad-dragon.com/shop/clearance?sizes[]=#{toy.size.to_s.downcase}&skus[][]=#{toy.sku}"
+    end
+
+    private def send_photo(watcher, toy, bot, image, msg)
+      bot.send_photo(
+        chat_id: watcher,
+        photo: image.full_filename,
+        disable_notification: true,
+        reply_to_message_id: msg == nil ? nil : msg.not_nil!.message_id
+      )
+    rescue e : TelegramBot::APIException
+      Application.logger.warn "[notify] Caught a #{e.class} while sending #{watcher} an image for #{toy.sku}/#{toy.size} -- image was: #{image.inspect}\n#{e.inspect_with_backtrace}"
     end
   end
 end


### PR DESCRIPTION
The notification sending background jobs went boom because of the following exception

```
TelegramBot::APIException: Error 400 in call to Telegram API : {"ok" => false, "error_code" => 400_i64, "description" => "Bad Request: wrong file identifier/HTTP URL specified"}
```

This results in the job to be retried, leading to this:

![image 2018-10-30 20 51 38](https://user-images.githubusercontent.com/1809170/47746082-98f8bf80-dc85-11e8-8634-9642e224178c.jpg)

The URLs were perfectly fine though.  Some debugging of the failed job:

```ruby
require "pp"    # => true
require "json"  # => true

job_json = %q!{"job":"{\"queue\":\"send_notification\",\"jid\":\"8440fc56940e7c3cba1c4702\",\"class\":\"Worker::SendNotification\",\"args\":[0,{\"id\":0,\"sku\":\"davidsheath\",\"price\":76.0,\"flop_reason\":\"beauty mark on tip\",\"type\":\"flop\",\"size\":4,\"firmness\":\"3\",\"cumtube\":0,\"suction_cup\":0,\"color\":\"BD Silver\",\"color_type\":\"solid\",\"color1\":\"c0c0c0\",\"color2\":\"FFFFFF\",\"color3\":\"\",\"original_text\":\"\",\"original_toy_id\":0,\"original_order_id\":0,\"created\":\"2018-10-26T16:33:37\",\"images\":[{\"id\":0,\"inventoryToyId\":0,\"fullFilename\":\"https://assets.bad-dragon.com/images/inventorytoys/DavidsSheathSilverBullet_stock.JPG\",\"thumbFilename\":\"https://assets.bad-dragon.com/images/inventorytoys/DavidsSheathSilverBullet_stock_thumb.JPG\",\"created\":\"2018-10-26T20:46:57\"},{\"id\":0,\"inventoryToyId\":0,\"fullFilename\":\"https://assets.bad-dragon.com/images/inventorytoys/ce9fd4d1683a7c5ac033f593108bc2c4.JPG\",\"thumbFilename\":\"https://assets.bad-dragon.com/images/inventorytoys/ce9fd4d1683a7c5ac033f593108bc2c4_thumb.JPG\",\"created\":\"2018-10-26T20:47:43\"}]}],\"created_at\":1540917609.380427,\"enqueued_at\":1540917609.38053,\"retry\":true}"}!

job = JSON.parse(job_json)
user_id, toy = JSON.parse(job["job"])["args"]
pp toy["images"].map { |image| image["fullFilename"] }

# >> ["https://assets.bad-dragon.com/images/inventorytoys/DavidsSheathSilverBullet_stock.JPG",
# >>  "https://assets.bad-dragon.com/images/inventorytoys/ce9fd4d1683a7c5ac033f593108bc2c4.JPG"]
```

Guess it's okay to not send images if Telegram says no to it ¯\\\_(ツ)\_/¯